### PR TITLE
Fixed bug in parameter argv count check 

### DIFF
--- a/delete.py
+++ b/delete.py
@@ -46,8 +46,8 @@ def delete(deployment_name, config_json):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        raise Exception("Please provide deployment name and API name")
+    if len(sys.argv) < 2:
+        raise Exception("Please provide deployment name and config name")
     deployment_name = sys.argv[1]
     config_json = sys.argv[2] if len(sys.argv) == 3 else "sagemaker_config.json"
 

--- a/deploy.py
+++ b/deploy.py
@@ -120,8 +120,8 @@ def deploy(bento_bundle_path, deployment_name, config_json):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        raise Exception("Please provide deployment name, bundle path and API name")
+    if len(sys.argv) < 3:
+        raise Exception("Please provide deployment name, bundle path and config name")
     bento_bundle_path = sys.argv[1]
     deployment_name = sys.argv[2]
     config_json = sys.argv[3] if len(sys.argv) == 4 else "sagemaker_config.json"

--- a/describe.py
+++ b/describe.py
@@ -49,8 +49,8 @@ def describe(deployment_name, config_file_path):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        raise Exception("Please provide deployment name and API name")
+    if len(sys.argv) < 2:
+        raise Exception("Please provide deployment name and config name")
     deployment_name = sys.argv[1]
     config_json = sys.argv[2] if len(sys.argv) == 3 else "sagemaker_config.json"
 

--- a/update.py
+++ b/update.py
@@ -32,8 +32,8 @@ def update(bento_bundle_path, deployment_name, config_json):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        raise Exception("Please provide deployment name, bundle path and API name")
+    if len(sys.argv) < 3:
+        raise Exception("Please provide deployment name, bundle path and config name")
     bento_bundle_path = sys.argv[1]
     deployment_name = sys.argv[2]
     config_json = sys.argv[3] if len(sys.argv) == 4 else "sagemaker_config.json"


### PR DESCRIPTION
Fix the bug in parameter count check in delete/describle/update/deploy scripts.

Reason:
config_json is optional and already has a default "sagemaker_config.json" to use. This change will fix the 'raise Exception errors 'issue if users use above scripts without setting config_json. Below is an example, ideally it should NOT raise a exception error. 

```
Eligible command:
python delete.py my-first-sagemaker-deployment
 
Unexpected error message:
raise Exception("Please provide deployment name and API name")
```

