### PR TITLE
Adding support for Multiple endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ You can try out the deployment script with the IrisClassifier for the iris datas
     ```bash
     python delete.py my-sagemaker-deployment
     ```
+## The Internals
+
+This section is all about how the deployment tool works internally and how the actual deployment happens so that if needed you can modify this tool
+to suit your deployment needs. Under the hood the deployment tool modifies the Bento Image to make it compatible with the [Sagemaker Endpoint](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html). 
+This image is then built and pushed into an ECR repository. All the other components are created as part of the cloudformation stack, which creates
+the API Gateway, Lambda Function, Sagmaker Model, Sagemaker Endpoint Config and Sagemaker Endpoint. We have used an HTTP API Gateway + Lambda Function design to
+expose the Sagemaker Endpoint since the Lambda function gives us a lot more flexibility.
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/5261489/133879514-5b91eb1d-d7ae-4f03-965d-98107bd19962.png" alt="invocation arch"/>
+</p>
+
+For each bento endpoint that you have, the tool creates the corresponding route in HTTP Gateway which invokes the Lambda function which in turn invokes the Sagmaker endpoint and proxies the results back to the client. Since we are using Cloudformation to create the stack you can easily change/modify the resource to match your deployment needs. [`generate_resources.py`](sagemaker/generate_resources.py) contains the functions used to generate the cloudformation template which you can modifiy to suit you needs.
 
 ## Deployment operations
 

--- a/deploy.py
+++ b/deploy.py
@@ -57,8 +57,10 @@ def deploy(bento_bundle_path, deployment_name, config_json):
 
     # if skip_stack_deployment is given in the config file, return
     if deployment_config.get("skip_stack_deployment", False):
-        console.print("Skipping creation of sagemaker resources. 'skip_stack_deployment'"
-                      " option is set in the config")
+        console.print(
+            "Skipping creation of sagemaker resources. 'skip_stack_deployment'"
+            " option is set in the config"
+        )
         return
 
     # specifies resources - model, endpoint-config, endpoint and api-gateway
@@ -90,9 +92,7 @@ def deploy(bento_bundle_path, deployment_name, config_json):
     # generate config for sagemaker endpoint
     sagemaker_resources.update(gen_endpoint(endpoint_name, endpoint_config_name))
     # generae config for API Gateway
-    sagemaker_resources.update(
-        gen_api_gateway(api_gateway_name, deployment_config["api_name"], endpoint_name)
-    )
+    sagemaker_resources.update(gen_api_gateway(api_gateway_name, bento_bundle_path))
 
     template_file_path = gen_cloudformation_template_with_resources(
         sagemaker_resources, deployable_path

--- a/deploy.py
+++ b/deploy.py
@@ -91,7 +91,14 @@ def deploy(bento_bundle_path, deployment_name, config_json):
     # generate config for sagemaker endpoint
     sagemaker_resources.update(gen_endpoint(endpoint_name, endpoint_config_name))
     # generae config for API Gateway
-    sagemaker_resources.update(gen_api_gateway(api_gateway_name, endpoint_name, bento_bundle_path))
+    sagemaker_resources.update(
+        gen_api_gateway(
+            api_gateway_name,
+            endpoint_name,
+            deployment_config["timeout"],
+            bento_bundle_path,
+        )
+    )
 
     template_file_path = gen_cloudformation_template_with_resources(
         sagemaker_resources, deployable_path

--- a/deploy.py
+++ b/deploy.py
@@ -70,7 +70,6 @@ def deploy(bento_bundle_path, deployment_name, config_json):
         gen_model(
             model_name,
             image_tag,
-            deployment_config["api_name"],
             deployment_config["timeout"],
             deployment_config["workers"],
         )
@@ -92,7 +91,7 @@ def deploy(bento_bundle_path, deployment_name, config_json):
     # generate config for sagemaker endpoint
     sagemaker_resources.update(gen_endpoint(endpoint_name, endpoint_config_name))
     # generae config for API Gateway
-    sagemaker_resources.update(gen_api_gateway(api_gateway_name, bento_bundle_path))
+    sagemaker_resources.update(gen_api_gateway(api_gateway_name, endpoint_name, bento_bundle_path))
 
     template_file_path = gen_cloudformation_template_with_resources(
         sagemaker_resources, deployable_path

--- a/describe.py
+++ b/describe.py
@@ -13,7 +13,7 @@ def describe(deployment_name, config_file_path):
     sagemaker_config = get_configuration_value(config_file_path)
 
     # if skip_stack_deployment is present in config.
-    if sagemaker_config.get('skip_stack_deployment', False):
+    if sagemaker_config.get("skip_stack_deployment", False):
         return None
 
     cf_client = boto3.client("cloudformation", sagemaker_config["region"])
@@ -42,8 +42,6 @@ def describe(deployment_name, config_file_path):
     outputs = stack_info.get("Outputs")
     outputs = {o["OutputKey"]: o["OutputValue"] for o in outputs}
     info_json.update(outputs)
-
-    info_json.update({'api_name': sagemaker_config['api_name']})
 
     return info_json
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ boto3
 docker
 pandas
 rich
+numpy
+pillow

--- a/sagemaker/generate_resources.py
+++ b/sagemaker/generate_resources.py
@@ -111,7 +111,7 @@ def gen_endpoint(endpoint_name, endpoint_config_name):
     return endpoint
 
 
-def gen_api_gateway(api_gateway_name, endpoint_name, bento_bundle_path):
+def gen_api_gateway(api_gateway_name, endpoint_name, timeout, bento_bundle_path):
     # basic API Gateway Config
     api_gateway = {
         "HttpApi": {
@@ -167,12 +167,13 @@ def gen_api_gateway(api_gateway_name, endpoint_name, bento_bundle_path):
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Runtime": "python3.9",
+                "Description": "Parse request and invoke Sagmeker Endpoint",
+                "Timeout": timeout,
                 "Role": {"Fn::Sub": "${LambdaExecutionRole.Arn}"},
                 "Handler": "index.lambda_handler",
                 "Code": {
                     "ZipFile": LAMBDA_FUNCION_CODE.format(endpoint_name=endpoint_name)
                 },
-                "Description": "Parse request and invoke Sagmeker Endpoint",
                 "TracingConfig": {"Mode": "Active"},
             },
         },

--- a/sagemaker/generate_resources.py
+++ b/sagemaker/generate_resources.py
@@ -144,11 +144,30 @@ def gen_api_gateway(api_gateway_name, endpoint_name, bento_bundle_path):
                 "ApiId": {"Ref": "HttpApi"},
             },
         },
+        "LambdaExecutionRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess",
+                    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+                ],
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": ["lambda.amazonaws.com"]},
+                            "Action": ["sts:AssumeRole"],
+                        }
+                    ],
+                },
+            },
+        },
         "Lambdafn": {
             "Type": "AWS::Lambda::Function",
             "Properties": {
                 "Runtime": "python3.9",
-                "Role": "arn:aws:iam::213386773652:role/service-role/EchoRequest-role-q2dtxtq7",
+                "Role": {"Fn::Sub": "${LambdaExecutionRole.Arn}"},
                 "Handler": "index.lambda_handler",
                 "Code": {
                     "ZipFile": LAMBDA_FUNCION_CODE.format(endpoint_name=endpoint_name)

--- a/sagemaker/lambda_function.py
+++ b/sagemaker/lambda_function.py
@@ -16,19 +16,19 @@ def lambda_handler(event, context):
 
     try:
         sagemaker_response = runtime.invoke_endpoint(
-            EndpointName='test-endpoint',
+            EndpointName="{endpoint_name}",
             ContentType=safeget(event, 'headers', 'content-type', default='application/json'),
             CustomAttributes=safeget(event, 'rawPath', default='')[1:],
             Body=b64decode(event.get('body')) if event.get('isBase64Encoded') else event.get('body')
         )
     except Exception as e:
-        return {
+        return {{
             'statusCode': e.response.get('OriginalStatusCode'),
             'body': e.response.get('Error')['Message']
-        }
+        }}
     else:
-        return {
+        return {{
             'statusCode': safeget(sagemaker_response, 'ResponseMetadata', 'HTTPStatusCode'),
             'body': sagemaker_response.get('Body').read()
-        }
+        }}
 """

--- a/sagemaker/lambda_function.py
+++ b/sagemaker/lambda_function.py
@@ -1,0 +1,34 @@
+LAMBDA_FUNCION_CODE = """
+import json
+import boto3
+from base64 import b64decode
+
+def safeget(dct, *keys, default=None):
+    for key in keys:
+        try:
+            dct = dct[key]
+        except KeyError:
+            return default
+    return dct
+
+def lambda_handler(event, context):
+    runtime = boto3.client('runtime.sagemaker')
+
+    try:
+        sagemaker_response = runtime.invoke_endpoint(
+            EndpointName='test-endpoint',
+            ContentType=safeget(event, 'headers', 'content-type', default='application/json'),
+            CustomAttributes=safeget(event, 'rawPath', default='')[1:],
+            Body=b64decode(event.get('body')) if event.get('isBase64Encoded') else event.get('body')
+        )
+    except Exception as e:
+        return {
+            'statusCode': e.response.get('OriginalStatusCode'),
+            'body': e.response.get('Error')['Message']
+        }
+    else:
+        return {
+            'statusCode': safeget(sagemaker_response, 'ResponseMetadata', 'HTTPStatusCode'),
+            'body': sagemaker_response.get('Body').read()
+        }
+"""

--- a/sagemaker/wsgi.py
+++ b/sagemaker/wsgi.py
@@ -41,14 +41,13 @@ def ping_view_func():
     return Response(response="\n", status=200, mimetype="application/json")
 
 
-def setup_routes(app, bento_service, api_name):
+def setup_routes(app, bento_service):
     """
     Setup routes required for AWS sagemaker
     /ping
     /invocations
     """
     app.add_url_rule("/ping", "ping", ping_view_func)
-    api = bento_service.get_inference_api(api_name)
     setup_bento_service_api_route(app, bento_service)
 
 
@@ -62,18 +61,17 @@ class BentomlSagemakerServer:
     BentomlSagemakerServer create an AWS Sagemaker compatibility REST API model server
     """
 
-    def __init__(self, bento_service, api_name, app_name=None):
+    def __init__(self, bento_service, app_name=None):
         app_name = bento_service.name if app_name is None else app_name
 
         self.bento_service = bento_service
         self.app = Flask(app_name)
-        setup_routes(self.app, self.bento_service, api_name)
+        setup_routes(self.app, self.bento_service)
 
     def start(self):
         self.app.run(port=AWS_SAGEMAKER_SERVE_PORT)
 
 
-api_name = os.environ.get("API_NAME", None)
 model_service = load_from_dir("/bento")
-server = BentomlSagemakerServer(model_service, api_name)
+server = BentomlSagemakerServer(model_service)
 app = server.app

--- a/sagemaker_config.json
+++ b/sagemaker_config.json
@@ -1,6 +1,5 @@
 {
     "region": "us-west-1",
-    "api_name": "predict",
     "skip_stack_deployment": false,
     "instance_type": "ml.t2.medium",
     "initial_instance_count": 1,

--- a/sagemaker_config.json
+++ b/sagemaker_config.json
@@ -1,7 +1,7 @@
 {
     "region": "us-west-1",
     "api_name": "predict",
-    "skip_stack_deployment": "false",
+    "skip_stack_deployment": false,
     "instance_type": "ml.t2.medium",
     "initial_instance_count": 1,
     "workers": 3,

--- a/tests/classifier.py
+++ b/tests/classifier.py
@@ -1,12 +1,11 @@
 # iris_classifier.py
 from bentoml import env, api, BentoService
-from bentoml.adapters import DataframeInput, JsonInput, FileInput
+from bentoml.adapters import DataframeInput, JsonInput, FileInput, ImageInput
 from bentoml.types import JsonSerializable, FileLike
 
 
 @env(infer_pip_packages=True)
 class TestService(BentoService):
-
     @api(input=DataframeInput(), batch=True)
     def dfapi(self, df):
         print(df)
@@ -24,3 +23,8 @@ class TestService(BentoService):
             return file_stream.bytes_
         else:
             return file_stream._stream.read()
+
+    @api(input=ImageInput(), batch=False)
+    def imageapi(self, img):
+        print(img.shape)
+        return img.shape

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,7 +76,7 @@ class Setup:
         return url
 
     def teardown(self):
-        # delete(self.deployment_name, self.config_file)
+        delete(self.deployment_name, self.config_file)
         shutil.rmtree(self.dirpath)
         print("Removed {}!".format(self.dirpath))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,6 @@ class Setup:
         config = """
             {
                 "region": "us-west-1",
-                "api_name": "dfapi",
                 "instance_type": "ml.t2.medium",
                 "initial_instance_count": 1,
                 "workers": 3,
@@ -72,12 +71,12 @@ class Setup:
         info_json = describe(self.deployment_name, self.config_file)
         url = info_json["EndpointURL"] + "/{}"
 
-        self.check_if_up(url.format('dfapi'))
+        self.check_if_up(url.format("dfapi"), num_attempts=2)
 
         return url
 
     def teardown(self):
-        delete(self.deployment_name, self.config_file)
+        # delete(self.deployment_name, self.config_file)
         shutil.rmtree(self.dirpath)
         print("Removed {}!".format(self.dirpath))
 
@@ -111,7 +110,7 @@ def test_df(url):
     # request as csv
     headers = {"content-type": "text/csv"}
     csv = DataFrame(input_array).to_csv(index=False)
-    resp = requests.post(url.format("dfapi"), data=csv, headers=headers)
+    resp = requests.post(url, data=csv, headers=headers)
     assert resp.ok
     assert DataFrame(resp.json()).to_json() == DataFrame(input_array).to_json()
 
@@ -132,7 +131,7 @@ def test_files(url):
 
     # request mulitpart/form-data
     file = {"audio": ("test", binary_data)}
-    resp = requests.post(url.format("fileapi"), files=file)
+    resp = requests.post(url, files=file)
     assert resp.ok
     assert resp.content == b'"test"'
 
@@ -152,7 +151,7 @@ if __name__ == "__main__":
         print("Setup successful")
 
         # list of tests to perform
-        TESTS = [(test_df, "dfapi")]
+        TESTS = [(test_df, "dfapi"), (test_files, "fileapi"), (test_json, "jsonapi")]
 
         for test_func, endpoint in TESTS:
             try:

--- a/update.py
+++ b/update.py
@@ -1,8 +1,7 @@
 import sys
 
-from utils import run_shell_command, console
+from utils import console
 from deploy import deploy
-from describe import describe
 
 
 def update(bento_bundle_path, deployment_name, config_json):
@@ -11,24 +10,6 @@ def update(bento_bundle_path, deployment_name, config_json):
     the stack too.
     """
     deploy(bento_bundle_path, deployment_name, config_json)
-
-    # point API Gateway to new the updated deployment
-    deploy_desc = describe(deployment_name, config_json)
-    api_gateway_id = deploy_desc.get('OutputApiId')
-    run_shell_command(
-        [
-            "aws",
-            "apigateway",
-            "create-deployment",
-            "--rest-api-id",
-            api_gateway_id,
-            "--stage-name",
-            "prod",
-            "--description",
-            "deploying update at ",
-        ]
-    )
-    print("Updating API Gateway")
 
 
 if __name__ == "__main__":

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -124,14 +124,11 @@ def gen_cloudformation_template_with_resources(resources: dict, project_dir):
         "Description": "An API Gateway to invoke Sagemaker Endpoint",
         "Resources": resources,
         "Outputs": {
-            "OutputApiId": {
-                "Value": {"Ref": "ApiGatewayRestApi"},
-                "Description": "Api generated Id",
-            },
             "EndpointURL": {
                 "Value": {
-                    "Fn::Sub": "https://${ApiGatewayRestApi}.execute-api.${AWS::Region}.amazonaws.com/${ApiGatewayStage}"
-                }
+                    "Fn::Sub": "${HttpApi.ApiEndpoint}"
+                },
+                "Description": "The endpoint for Sagemaker inference"
             },
         },
     }


### PR DESCRIPTION
This PR uses a HttpAPI proxy + Lambda function to call the Sagemaker endpoint. This allows us to add support for multiple endpoints and better integration for the different input handlers and better error messages.