### PR TITLE
fix: lambda function and sagemaker updation order

### DIFF
--- a/bentoctl_sagemaker/templates/terraform_default.tf
+++ b/bentoctl_sagemaker/templates/terraform_default.tf
@@ -151,7 +151,7 @@ def lambda_handler(event, context):
     try:
         sagemaker_response = runtime.invoke_endpoint(
             EndpointName="${var.deployment_name}-endpoint",
-            ContentType=safeget(event, 'headers', 'content-type', default='application/json'),
+            ContentType=safeget(event, 'headers', 'Content-Type', default='application/json'),
             CustomAttributes=safeget(event, 'path', default='')[1:],
             Body=b64decode(event.get('body')) if event.get('isBase64Encoded') else event.get('body')
         )

--- a/bentoctl_sagemaker/templates/terraform_default.tf
+++ b/bentoctl_sagemaker/templates/terraform_default.tf
@@ -82,7 +82,10 @@ resource "aws_iam_role" "iam_role_sagemaker" {
 }
 
 resource "aws_sagemaker_model" "sagemaker_model" {
-  name               = "${var.deployment_name}-model"
+  lifecycle {
+    create_before_destroy = true
+  }
+  name               = "${var.deployment_name}-model-${var.image_version}"
   execution_role_arn = resource.aws_iam_role.iam_role_sagemaker.arn
   primary_container {
     image = "${data.aws_ecr_repository.service.repository_url}@${data.aws_ecr_image.service_image.id}"
@@ -91,7 +94,10 @@ resource "aws_sagemaker_model" "sagemaker_model" {
 }
 
 resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
-  name = "${var.deployment_name}-endpoint-config"
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "${var.deployment_name}-endpoint-config-${var.image_version}"
 
   production_variants {
     initial_instance_count = var.initial_instance_count

--- a/bentoctl_sagemaker/templates/terraform_with_data_capture.tf
+++ b/bentoctl_sagemaker/templates/terraform_with_data_capture.tf
@@ -171,7 +171,7 @@ def lambda_handler(event, context):
     try:
         sagemaker_response = runtime.invoke_endpoint(
             EndpointName="${var.deployment_name}-endpoint",
-            ContentType=safeget(event, 'headers', 'content-type', default='application/json'),
+            ContentType=safeget(event, 'headers', 'Content-Type', default='application/json'),
             CustomAttributes=safeget(event, 'path', default='')[1:],
             Body=b64decode(event.get('body')) if event.get('isBase64Encoded') else event.get('body')
         )

--- a/bentoctl_sagemaker/templates/terraform_with_data_capture.tf
+++ b/bentoctl_sagemaker/templates/terraform_with_data_capture.tf
@@ -92,7 +92,10 @@ resource "aws_iam_role" "iam_role_sagemaker" {
 }
 
 resource "aws_sagemaker_model" "sagemaker_model" {
-  name               = "${var.deployment_name}-model"
+  lifecycle {
+    create_before_destroy = true
+  }
+  name               = "${var.deployment_name}-model-${var.image_version}"
   execution_role_arn = resource.aws_iam_role.iam_role_sagemaker.arn
   primary_container {
     image = "${data.aws_ecr_repository.service.repository_url}@${data.aws_ecr_image.service_image.id}"
@@ -101,7 +104,10 @@ resource "aws_sagemaker_model" "sagemaker_model" {
 }
 
 resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
-  name = "${var.deployment_name}-endpoint-config"
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "${var.deployment_name}-endpoint-config-${var.image_version}"
 
   production_variants {
     initial_instance_count = var.initial_instance_count


### PR DESCRIPTION
- fixes issue mentioned in #41 
- added a lifecycle attribute into sagemaker to specify the correct order for updation in terraform. 
- `sagemaker_model` and `sagemaker_endpoint_config` will now be named with the bento-tag.

closes #41 