### PR TITLE
feat: better help messages and default when directly invoking sagemaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ This quickstart will walk you through deploying a bento as an AWS Sagemaker Endp
 
     0%
     ```
+
+> Note: You can also [invoke the Sagemaker endpoint directly](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html). If there is only one service sagemaker deployment will choose that one. If there is more than one you can specify which service to use by passing the `X-Amzn-SageMaker-Custom-Attributes` with the name of the sevice.
    
 7. Delete deployment
     Use the `bentoctl destroy` command to remove the registry and the deployment

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This quickstart will walk you through deploying a bento as an AWS Sagemaker Endp
 
         Outputs:
 
-        base_url = "https://rwfej5qsf6.execute-api.ap-south-1.amazonaws.com/"
+        endpoint = "https://rwfej5qsf6.execute-api.ap-south-1.amazonaws.com/"
         ecr_image_tag = "213386773652.dkr.ecr.ap-south-1.amazonaws.com/quickstart:sfx3dagmpogmockr"
         ```
 
@@ -160,7 +160,7 @@ This quickstart will walk you through deploying a bento as an AWS Sagemaker Endp
     The `iris_classifier` uses the `/classify` endpoint for receiving requests so the full URL for the classifier will be in the form `{EndpointUrl}/classify`.
 
     ```bash
-    URL=$(terraform output -json | jq -r .base_url.value)classify
+    URL=$(terraform output -json | jq -r .endpoint.value)classify
     curl -i \
       --header "Content-Type: application/json" \
       --request POST \

--- a/bentoctl_sagemaker/sagemaker/service.py
+++ b/bentoctl_sagemaker/sagemaker/service.py
@@ -1,8 +1,8 @@
+import logging
+
 import bentoml
-from starlette.applications import Starlette
+from bentoml.exceptions import BentoMLException
 from starlette.requests import Request
-from starlette.responses import JSONResponse
-from starlette.routing import Mount, Route
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 AWS_SAGEMAKER_SERVE_PORT = 8080
@@ -28,8 +28,29 @@ class SagemakerMiddleware:
                 scope["path"] = BENTOML_HEALTH_CHECK_PATH
 
             if req.url.path == "/invocations":
-                assert AWS_CUSTOM_ENDPOINT_HEADER in req.headers
-                api_path = req.headers[AWS_CUSTOM_ENDPOINT_HEADER]
+                if AWS_CUSTOM_ENDPOINT_HEADER not in req.headers:
+                    if len(svc.apis) == 1:
+                        # only one api, use it
+                        api_path, *_ = svc.apis
+                        logging.warning(
+                            f"'{AWS_CUSTOM_ENDPOINT_HEADER}' not found in request header. Using defualt {api_path} service."
+                        )
+                    else:
+                        logging.error(
+                            f"'{AWS_CUSTOM_ENDPOINT_HEADER}' not found inside request header. If you are directly invoking the Sagemaker Endpoint pass in the '{AWS_CUSTOM_ENDPOINT_HEADER}' with the bentoml service name that you want to invoke."
+                        )
+                        raise BentoMLException(
+                            f"'{AWS_CUSTOM_ENDPOINT_HEADER}' not found inside request header."
+                        )
+                else:
+                    api_path = req.headers[AWS_CUSTOM_ENDPOINT_HEADER]
+                    if api_path not in svc.apis:
+                        logging.error(
+                            "API Service passed via the '{AWS_CUSTOM_ENDPOINT_HEADER}' not found in the bentoml service."
+                        )
+                        raise BentoMLException(
+                            "API Service passed via the '{AWS_CUSTOM_ENDPOINT_HEADER}' not found in the bentoml service."
+                        )
                 scope["path"] = "/" + api_path
 
         await self.app(scope, receive, send)

--- a/bentoctl_sagemaker/sagemaker/service.py
+++ b/bentoctl_sagemaker/sagemaker/service.py
@@ -9,6 +9,8 @@ AWS_SAGEMAKER_SERVE_PORT = 8080
 AWS_CUSTOM_ENDPOINT_HEADER = "X-Amzn-SageMaker-Custom-Attributes"
 BENTOML_HEALTH_CHECK_PATH = "/livez"
 
+logger = logging.getLogger(__name__)
+
 # use standalone_load so that the path is not changed back
 # after loading.
 svc = bentoml.load(".", standalone_load=True)
@@ -32,11 +34,11 @@ class SagemakerMiddleware:
                     if len(svc.apis) == 1:
                         # only one api, use it
                         api_path, *_ = svc.apis
-                        logging.warning(
+                        logger.info(
                             f"'{AWS_CUSTOM_ENDPOINT_HEADER}' not found in request header. Using defualt {api_path} service."
                         )
                     else:
-                        logging.error(
+                        logger.error(
                             f"'{AWS_CUSTOM_ENDPOINT_HEADER}' not found inside request header. If you are directly invoking the Sagemaker Endpoint pass in the '{AWS_CUSTOM_ENDPOINT_HEADER}' with the bentoml service name that you want to invoke."
                         )
                         raise BentoMLException(
@@ -45,7 +47,7 @@ class SagemakerMiddleware:
                 else:
                     api_path = req.headers[AWS_CUSTOM_ENDPOINT_HEADER]
                     if api_path not in svc.apis:
-                        logging.error(
+                        logger.error(
                             "API Service passed via the '{AWS_CUSTOM_ENDPOINT_HEADER}' not found in the bentoml service."
                         )
                         raise BentoMLException(


### PR DESCRIPTION
1. option to ensure we invoke the default API when the header is missing. This way for simple bentoml services, you can invoke the Sagemaker endpoint directly without the API gateway without worrying about the headers.
2. Better error messages in case the users invoke it directly without passing the header and there is more than one service.